### PR TITLE
Add coverage + badges to the README

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,3 +24,18 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm test
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm run test:coverage
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Version](https://img.shields.io/npm/v/gaussian)](https://www.npmjs.com/package/gaussian)
+[![Tests](https://github.com/errcw/gaussian/workflows/tests/badge.svg)](https://github.com/errcw/gaussian/actions/workflows/tests.yml)
+[![Coverage Status](https://coveralls.io/repos/github/errcw/gaussian/badge.svg?branch=master)](https://coveralls.io/github/errcw/gaussian?branch=master)
+[![Downloads](https://img.shields.io/npm/dy/gaussian)](https://www.npmjs.com/package/gaussian)
+[![License](https://img.shields.io/npm/l/gaussian)](https://github.com/errcw/gaussian/blob/master/LICENSE)
+
 # gaussian
 
 A JavaScript model of the [Normal](http://en.wikipedia.org/wiki/Normal_distribution)
@@ -6,6 +12,7 @@ A JavaScript model of the [Normal](http://en.wikipedia.org/wiki/Normal_distribut
 ## API
 
 ### Creating a Distribution
+
 ```javascript
 var gaussian = require('gaussian');
 var distribution = gaussian(mean, variance);
@@ -14,11 +21,13 @@ var sample = distribution.ppf(Math.random());
 ```
 
 ### Properties
+
 - `mean`: the mean (μ) of the distribution
 - `variance`: the variance (σ^2) of the distribution
 - `standardDeviation`: the standard deviation (σ) of the distribution
 
 ### Probability Functions
+
 - `pdf(x)`: the probability density function, which describes the probability
   of a random variable taking on the value _x_
 - `cdf(x)`: the cumulative distribution function, which describes the
@@ -26,6 +35,7 @@ var sample = distribution.ppf(Math.random());
 - `ppf(x)`: the percent point function, the inverse of _cdf_
 
 ### Combination Functions
+
 - `mul(d)`: returns the product distribution of this and the given distribution; equivalent to `scale(d)` when d is a constant
 - `div(d)`: returns the quotient distribution of this and the given distribution; equivalent to `scale(1/d)` when d is a constant
 - `add(d)`: returns the result of adding this and the given distribution's means and variances
@@ -33,4 +43,5 @@ var sample = distribution.ppf(Math.random());
 - `scale(c)`: returns the result of scaling this distribution by the given constant
 
 ### Generation Function
+
 - `random(n)`: returns an array of generated `n` random samples correspoding to the Gaussian parameters.

--- a/lib/box-muller.js
+++ b/lib/box-muller.js
@@ -20,5 +20,6 @@
 })
 (typeof(exports) !== "undefined"
     ? function(e) { module.exports = e; }
+    // istanbul ignore next
     : function(e) { this["boxmuller"] = e; });
   

--- a/lib/gaussian.js
+++ b/lib/gaussian.js
@@ -121,4 +121,6 @@
 })
 (typeof(exports) !== "undefined"
     ? function(e) { module.exports = e; }
+    // istanbul ignore next
     : function(e) { this["gaussian"] = e; });
+

--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
     "type": "git",
     "url": "git://github.com/errcw/gaussian.git"
   },
-  "licenses": {
-    "type": "MIT",
-    "url": "http://github.com/errcw/gaussian/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "main": "lib/gaussian",
   "scripts": {
     "test": "jest",

--- a/test/gaussian.test.js
+++ b/test/gaussian.test.js
@@ -112,3 +112,26 @@ it('test generated sample distribution', () => {
   expect(mean).toBeCloseTo(-1.0);
   expect(variance).toBeCloseTo(0.65);
 });
+
+/**
+ * Coverage for gaussian.js:20
+ */
+it('ceils ppf >= 1', () => {
+  expect.assertions(3);
+  const normal = gaussian(0, 1);
+  expect(normal.ppf(1)).toBe(141.4213562373095);
+  expect(normal.ppf(1.1)).toBe(141.4213562373095);
+  expect(normal.ppf(100)).toBe(141.4213562373095);
+});
+
+/**
+ * Coverage for gaussian.js:21
+ */
+it('ceils ppf <= 0', () => {
+  expect.assertions(4);
+  const normal = gaussian(0, 1);
+  expect(normal.ppf(0)).toBe(-141.4213562373095);
+  expect(normal.ppf(-0)).toBe(-141.4213562373095);
+  expect(normal.ppf(-0.1)).toBe(-141.4213562373095);
+  expect(normal.ppf(-1)).toBe(-141.4213562373095);
+});


### PR DESCRIPTION
You may need to goto https://coveralls.io/ to setup coverage on there first, but this code should do the trick into running a Github Action which updates it and _humble brags_ the 100% coverage, so it looks like this...

-----

<img width="937" alt="screen" src="https://user-images.githubusercontent.com/1247668/110077104-7e671180-7d7d-11eb-9820-ae020ec389b6.png">
