### PR TITLE
Added option to use a custom function as the random number generator.

### DIFF
--- a/lib/box-muller.js
+++ b/lib/box-muller.js
@@ -6,9 +6,27 @@
 (function(exports){
   const PRECISION = 1e9;
   const _2PI = Math.PI * 2;
-  function generateGaussian(mean,std){
-    var u1 = Math.random();
-    var u2 = Math.random();
+
+  /**
+   *
+   * @param {number} mean
+   * @param {number} std
+   * @param randFn - an optional function that returns a float between 0 (inclusive) and 1
+   * (exclusive).  Use this if you want to pass in a random number generator other than
+   * Math.random().
+   * @returns {number}
+   */
+  function generateGaussian(mean,std, randFn = null){
+    var u1;
+    var u2;
+    if (randFn) {
+      u1 = randFn();
+      u2 = randFn();
+    }
+    else {
+      u1 = Math.random();
+      u2 = Math.random();
+    }
     
     var z0 = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(_2PI * u2);
     var z1 = Math.sqrt(-2.0 * Math.log(u1)) * Math.sin(_2PI * u2);

--- a/lib/gaussian.js
+++ b/lib/gaussian.js
@@ -100,12 +100,20 @@
     return gaussian(this.mean * c, this.variance * c * c);
   };
 
-  // Generate [num] random samples
-  Gaussian.prototype.random = function(num){
+
+  /**
+   * Generate [num] random samples
+   * @param {number} num
+   * @param randFn - an optional function that returns a float between 0 (inclusive) and 1
+   * (exclusive).  Use this if you want to pass in a random number generator other than
+   * Math.random().
+   * @returns {number[]}
+   */
+  Gaussian.prototype.random = function(num, randFn = null){
     let mean = this.mean;
     let std = this.standardDeviation;
     return Array(num).fill(0).map(() => {
-      return generateGaussian(mean,std)
+      return generateGaussian(mean,std, randFn)
     })
   };
 

--- a/test/gaussian.test.js
+++ b/test/gaussian.test.js
@@ -99,6 +99,12 @@ it('test generate samples', () => {
   outcomes.forEach((outcome) => expect(typeof outcome).toBe('number'));
 });
 
+it('test custom RNG', () => {
+  var sillyFn = () => .5;
+  const outcomes = gaussian(0, 0.3).random(2, sillyFn);
+  outcomes.forEach((outcome) => expect(outcome).toBeCloseTo(-0.644894028, 8));
+});
+
 /**
  * Just a naive and simple
  */


### PR DESCRIPTION
Added option to use a custom function as the random number generator.  This allows the caller, for example, to use a seedable random number generator, since Math.random() cannot be seeded.